### PR TITLE
add backwards compatibility for NIGHTSCOUT_HOST and API_SECRET

### DIFF
--- a/gaps.go
+++ b/gaps.go
@@ -66,7 +66,7 @@ func findGaps(entries []time.Time, gapDuration time.Duration) []Gap {
 }
 
 const (
-	edgeMargin = 1 * time.Minute
+	edgeMargin = 2 * time.Second
 )
 
 // Missing returns the Entry values that fall within the given gaps.

--- a/nightscout.go
+++ b/nightscout.go
@@ -14,9 +14,11 @@ import (
 )
 
 const (
-	siteEnvVar      = "NIGHTSCOUT_SITE"
-	apiSecretEnvVar = "NIGHTSCOUT_API_SECRET"
-	deviceEnvVar    = "NIGHTSCOUT_DEVICE"
+	siteEnvVar            = "NIGHTSCOUT_SITE"
+	legacySiteEnvVar      = "NIGHTSCOUT_HOST"
+	apiSecretEnvVar       = "NIGHTSCOUT_API_SECRET"
+	legacyApiSecretEnvVar = "API_SECRET"
+	deviceEnvVar          = "NIGHTSCOUT_DEVICE"
 )
 
 var (
@@ -47,7 +49,10 @@ func SetNoUpload(flag bool) {
 func sitename() (string, error) {
 	site := os.Getenv(siteEnvVar)
 	if len(site) == 0 {
-		return "", fmt.Errorf("%s is not set", siteEnvVar)
+		site := os.Getenv(legacySiteEnvVar)
+		if len(site) == 0 {
+			return "", fmt.Errorf("%s is not set", siteEnvVar)
+		}
 	}
 	return site, nil
 }
@@ -55,7 +60,10 @@ func sitename() (string, error) {
 func apiSecret() (string, error) {
 	secret := os.Getenv(apiSecretEnvVar)
 	if len(secret) == 0 {
-		return "", fmt.Errorf("%s is not set", apiSecretEnvVar)
+		secret := os.Getenv(legacyApiSecretEnvVar)
+		if len(secret) == 0 {
+			return "", fmt.Errorf("%s is not set", apiSecretEnvVar)
+		}
 	}
 	return secret, nil
 }


### PR DESCRIPTION
In OpenAPS loops configured by oref0-setup, we still use NIGHTSCOUT_HOST and API_SECRET, so it'll be easiest to integrate this if we add in backwards compatibility with those ENV var names.