### PR TITLE
allow CGM values to be uploaded to NS after 2 seconds, not 60

### DIFF
--- a/gaps.go
+++ b/gaps.go
@@ -66,7 +66,7 @@ func findGaps(entries []time.Time, gapDuration time.Duration) []Gap {
 }
 
 const (
-	edgeMargin = 1 * time.Minute
+	edgeMargin = 2 * time.Second
 )
 
 // Missing returns the Entry values that fall within the given gaps.


### PR DESCRIPTION
An edgeMargin of 1 minute prevents `g4update` from uploading CGM readings until 1 minute after their timestamp.  This changes the edgeMargin to 2 seconds to allow them to be uploaded as fast as they can be read, while hopefully avoiding any problems with duplicates.