### PR TITLE
availability to set token wo env vars

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/glcmts/nightscout
+
+go 1.13

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,0 @@
-module github.com/ecc1/nightscout
-
-go 1.13


### PR DESCRIPTION
I've been trying to use multiple Nightscout instances with different tokens, with this, you can set the Token without use env var (because each instance will have a different one):

```
package main

import (
        "log"

        "github.com/ecc1/nightscout"
)

func main() {
        site, err := nightscout.Site("https://XXXXXX.herokuapp.com")
        site.Token = "xxxx-xxxxxxxx"
        if err != nil {
                log.Fatal(err)
        }
        entries, err := site.DownloadEntries(10)
        if err != nil {
                log.Fatal(err)
        }
        entries.Print()
}
```